### PR TITLE
Fix bug in getResources when used with lists

### DIFF
--- a/packages/redux-resource/src/utils/get-resources.js
+++ b/packages/redux-resource/src/utils/get-resources.js
@@ -15,7 +15,7 @@ export default function(state, resourceName, idsOrList) {
       return [];
     }
 
-    idsList = list.ids;
+    idsList = list;
   } else {
     idsList = idsOrList;
   }

--- a/packages/redux-resource/test/unit/utils/get-resources.js
+++ b/packages/redux-resource/test/unit/utils/get-resources.js
@@ -1,4 +1,4 @@
-import {getResources, requestStatuses} from '../../../src';
+import {getResources} from '../../../src';
 
 describe('getResources', function() {
   beforeEach(() => {
@@ -12,14 +12,8 @@ describe('getResources', function() {
         },
         meta: {},
         lists: {
-          dashboardSearch: {
-            ids: [10, 22, 102],
-            status: requestStatuses.SUCCEEDED
-          },
-          detailsPage: {
-            ids: [],
-            status: requestStatuses.FAILED
-          },
+          dashboardSearch: [10, 22, 102],
+          detailsPage: [],
           malformedList: {}
         }
       },


### PR DESCRIPTION
This PR fixes a bug where `getResources` will always return an empty array when used on lists. A repro is available [here](https://runkit.com/yihangho/redux-resource-get-resources-bug).

I'm unable to get the tests for other packages to run - when I run `npm run install`, it complains that `Error: Cannot find module 'redux-resource'`. Full log available [here](https://gist.github.com/yihangho/01c7948e8ba312284a97bb4cc60d6f5a).