### PR TITLE
Use babel-external-helpers plugin

### DIFF
--- a/packages/redux-resource-plugins/.babelrc
+++ b/packages/redux-resource-plugins/.babelrc
@@ -4,7 +4,8 @@
       "presets": [
         ["env", {"modules": false}],
         "stage-3"
-      ]
+      ],
+      "plugins": ["external-helpers"]
     },
     "commonjs": {
       "plugins": [

--- a/packages/redux-resource-prop-types/.babelrc
+++ b/packages/redux-resource-prop-types/.babelrc
@@ -4,7 +4,8 @@
       "presets": [
         ["env", {"modules": false}],
         "stage-3"
-      ]
+      ],
+      "plugins": ["external-helpers"]
     },
     "commonjs": {
       "plugins": [

--- a/packages/redux-resource-xhr/.babelrc
+++ b/packages/redux-resource-xhr/.babelrc
@@ -4,7 +4,8 @@
       "presets": [
         ["env", {"modules": false}],
         "stage-3"
-      ]
+      ],
+      "plugins": ["external-helpers"]
     },
     "commonjs": {
       "plugins": [

--- a/packages/redux-resource/.babelrc
+++ b/packages/redux-resource/.babelrc
@@ -4,7 +4,8 @@
       "presets": [
         ["env", {"modules": false}],
         "stage-3"
-      ]
+      ],
+      "plugins": ["external-helpers"]
     },
     "commonjs": {
       "plugins": [


### PR DESCRIPTION
This ensures that Babel doesn't duplicate helpers.

File size diff:

`redux-resource`: 2.48kb => 2.37kb
`redux-resource-plugins`: 1.38kb => 1.35kb
`redux-resource-xhr`: 1.26kb => 1.25kb
`redux-resource-prop-types`: no change

As part of #127