### PR TITLE
redux-resource-action-creators

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
   * [Related Resources](/docs/recipes/related-resources.md)
   * [Caching](/docs/recipes/caching.md)
 * [Ecosystem Extras](/docs/extras/README.md)
+  * [Redux Resource Action Creators](/docs/extras/redux-resource-action-creators.md)
   * [Redux Resource XHR](/docs/extras/redux-resource-xhr.md)
   * [Redux Resource Prop Types](/docs/extras/redux-resource-prop-types.md)
   * [Redux Resource Plugins](/docs/extras/redux-resource-plugins.md)

--- a/docs/extras/README.md
+++ b/docs/extras/README.md
@@ -2,6 +2,7 @@
 
 The Redux Resource ecosystem provides bits of code that make working with the library even better.
 
+* [Redux Resource Action Creators](/docs/extras/redux-resource-action-creators.md)
 * [Redux Resource XHR](/docs/extras/redux-resource-xhr.md)
 * [Redux Resource Plugins](/docs/extras/redux-resource-plugins.md)
 * [Redux Resource Prop Types](/docs/extras/redux-resource-prop-types.md)

--- a/docs/extras/redux-resource-action-creators.md
+++ b/docs/extras/redux-resource-action-creators.md
@@ -1,0 +1,155 @@
+# Redux Resource Action Creators
+
+[![npm version](https://img.shields.io/npm/v/redux-resource-action-creators.svg)](https://www.npmjs.com/package/redux-resource-action-creators)
+[![gzip size](http://img.badgesize.io/https://unpkg.com/redux-resource-action-creators/dist/redux-resource-action-creators.min.js?compression=gzip)](https://unpkg.com/redux-resource-action-creators/dist/redux-resource-action-creators.min.js)
+
+This library makes it more convenient to create valid Redux Resource actions. It helps out in two ways:
+
+1. Remembering the [CRUD Action Types](/docs/api-reference/action-types.md) can be difficult
+2. Often times, your "start" and "end" actions share many properties, and it can be verbose to copy + paste
+  those properties
+
+Unlike [Redux Resource XHR](/docs/extras/redux-resource-xhr.md), these action creators do not make the requests
+for you. All this library does is create the actions themselves.
+
+### Installation
+
+Install `redux-resource-action-creators` from npm:
+
+`npm install redux-resource-action-creators --save`
+
+Then, import `createActionCreators` in your application:
+
+```js
+import createActionCreators from 'redux-resource-action-creators';
+```
+
+### Usage
+
+This library has a single export, `createActionCreators`.
+
+### `createActionCreators( crudAction, actionDefaults )`
+
+#### Arguments
+
+1. `crudAction`: *(String)* The CRUD operation being performed. One of "create",
+  "read", "update", or "delete". This determines the
+  [CRUD Action types](/docs/api-reference/action-types.md) that are dispatched.
+
+2. `actionDefaults` *(Object)*: Properties that will be included on each dispatched
+    action. The [the CRUD Action guide](/docs/guides/crud-actions.md) lists possible
+    options, such as `resourceName` and `resources`. You *must* include `resourceName`.
+
+#### Returns
+
+(*`Object`*): An object with four methods: `pending`, `succeeded`, `failed`, and `null`.
+  These action creators return actions for you, based on the action properties that
+  you provide to them.
+
+#### Example
+
+```js
+import createActionCreators from 'redux-resource-action-creators';
+import store from './store';
+
+const readActionCreators = createActionCreators('read', {
+  resourceName: 'books',
+  request: 'getHomePageBooks',
+  list: 'homePageBooks',
+  mergeListIds: false
+});
+
+store.dispatch(readActionCreators.pending());
+
+const req = fetchData((err, res, body) => {
+  if (req.aborted) {
+    store.dispatch(readActionCreators.null());
+  } else if (err) {
+    store.dispatch(readActionCreators.failed());
+  } else {
+    store.dispatch(readActionCreators.succeeded({
+      resources: body
+    }));
+  }
+});
+```
+
+To understand why you might use this library, compare that example versus this common Redux
+Resource code:
+
+```js
+import { actionTypes } from 'redux-resource';
+import store from './store';
+
+store.dispatch({
+  type: actionTypes.READ_RESOURCES_PENDING,
+  resourceName: 'books',
+  request: 'getHomePageBooks',
+  list: 'homePageBooks'
+});
+
+const req = fetchData((err, res, body) => {
+  if (req.aborted) {
+    store.dispatch({
+      type: actionTypes.READ_RESOURCES_NULL,
+      resourceName: 'books',
+      request: 'getHomePageBooks',
+      list: 'homePageBooks'
+    });
+  } else if (err) {
+    store.dispatch({
+      type: actionTypes.READ_RESOURCES_FAILED,
+      resourceName: 'books',
+      request: 'getHomePageBooks',
+      list: 'homePageBooks'
+    });
+  } else {
+    store.dispatch(readActionCreators.succeeded({
+      type: actionTypes.READ_RESOURCES_SUCCEEDED,
+      resourceName: 'books',
+      request: 'getHomePageBooks',
+      list: 'homePageBooks',
+      resources: body
+    }));
+  }
+});
+```
+
+All that this library does is provides a simple pattern to write less, more expressive code. If you'd like, you could get many
+of the same benefits by defining shared action properties, and then spreading them in your actions:
+
+```js
+import { actionTypes } from 'redux-resource';
+import store from './store';
+
+const actionDefaults = {
+  resourceName: 'books',
+  request: 'getHomePageBooks',
+  list: 'homePageBooks'
+};
+
+store.dispatch({
+  ...actionDefaults,
+  type: actionTypes.READ_RESOURCES_PENDING,
+});
+
+const req = fetchData((err, res, body) => {
+  if (req.aborted) {
+    store.dispatch({
+      ...actionDefaults,
+      type: actionTypes.READ_RESOURCES_NULL,
+    });
+  } else if (err) {
+    store.dispatch({
+      ...actionDefaults,
+      type: actionTypes.READ_RESOURCES_FAILED,
+    });
+  } else {
+    store.dispatch(readActionCreators.succeeded({
+      ...actionDefaults,
+      type: actionTypes.READ_RESOURCES_SUCCEEDED,
+      resources: body
+    }));
+  }
+});
+```

--- a/docs/extras/redux-resource-xhr.md
+++ b/docs/extras/redux-resource-xhr.md
@@ -49,7 +49,7 @@ An action creator for CRUD requests.
   "read", "update", or "delete". This determines the
   [CRUD Action types](/docs/api-reference/action-types.md) that are dispatched.
 
-1. `options` *(Object)*: Options to configure the CRUD request.
+2. `options` *(Object)*: Options to configure the CRUD request.
 
   * `actionDefaults`: *(Object)* Properties that will be included on each dispatched
     action. All of [the CRUD Action options](/docs/guides/crud-actions.md) are

--- a/packages/redux-resource-action-creators/.babelrc
+++ b/packages/redux-resource-action-creators/.babelrc
@@ -1,0 +1,34 @@
+{
+  "env": {
+    "build": {
+      "presets": [
+        ["env", {"modules": false}],
+        "stage-3"
+      ],
+      "plugins": ["external-helpers"]
+    },
+    "es": {
+      "presets": [
+        ["env", {"modules": false}],
+        "stage-3"
+      ]
+    },
+    "commonjs": {
+      "plugins": [
+        ["transform-es2015-modules-commonjs", {"loose": true}]
+      ],
+      "presets": [
+        "stage-3"
+      ]
+    },
+    "test": {
+      "presets": [
+        "env",
+        "stage-3"
+      ],
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
+}

--- a/packages/redux-resource-action-creators/.npmrc
+++ b/packages/redux-resource-action-creators/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/redux-resource-action-creators/README.md
+++ b/packages/redux-resource-action-creators/README.md
@@ -1,0 +1,16 @@
+# Redux Resource Action Creators
+
+Action creators for creating Redux Resource actions.
+
+### Installation
+
+To install the latest version:
+
+```
+npm install --save redux-resource-action-creators
+```
+
+### Documentation
+
+View the documentation at
+**[redux-resource.js.org ⇗](https://redux-resource.js.org/)**.

--- a/packages/redux-resource-action-creators/package.json
+++ b/packages/redux-resource-action-creators/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "redux-resource-action-creators",
+  "version": "1.0.0-alpha.1",
+  "description": "Action creators for creating Redux Resource actions.",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "scripts": {
+    "clean": "rimraf dist tmp",
+    "prepublish": "in-publish && npm run build || not-in-publish",
+    "lint": "eslint src/**/*.js test/**/*.js webpack.config.js",
+    "build": "npm run clean && npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:commonjs",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
+    "build:umd": "cross-env NODE_ENV=development BABEL_ENV=build rollup -c -i src/index.js -o dist/redux-resource-prop-types.js",
+    "build:umd:min": "cross-env NODE_ENV=production BABEL_ENV=build rollup -c -i src/index.js -o dist/redux-resource-prop-types.min.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jmeas/redux-resource.git"
+  },
+  "keywords": [
+    "redux",
+    "boilerplate",
+    "resource",
+    "resources",
+    "framework",
+    "crud",
+    "http",
+    "xhr",
+    "state",
+    "data",
+    "store",
+    "reducer",
+    "reducers",
+    "action",
+    "action creators",
+    "creator",
+    "creators"
+  ],
+  "author": "Stephen Rivas Jr <sprjr@me.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jmeas/redux-resource/issues"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "es"
+  ],
+  "homepage": "https://redux-resource.js.org",
+  "dependencies": {
+    "redux-resource": "^2.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "6.23.0",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-istanbul": "^4.1.4",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-stage-3": "^6.17.0",
+    "babel-register": "^6.24.1",
+    "cross-env": "^5.0.1",
+    "in-publish": "^2.0.0",
+    "mocha": "^3.4.2",
+    "rimraf": "^2.6.1",
+    "rollup": "^0.45.1",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^1.2.1",
+    "rollup-plugin-uglify": "^2.0.1",
+    "webpack": "^3.1.0"
+  },
+  "peerDependencies": {
+    "redux": "3.x"
+  }
+}

--- a/packages/redux-resource-action-creators/rollup.config.js
+++ b/packages/redux-resource-action-creators/rollup.config.js
@@ -1,0 +1,40 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import uglify from 'rollup-plugin-uglify';
+import replace from 'rollup-plugin-replace';
+
+var env = process.env.NODE_ENV;
+var config = {
+  format: 'umd',
+  moduleName: 'ReduxResourceActionCreators',
+  external: ['redux-resource'],
+  globals: {
+    'redux-resource': 'ReduxResource'
+  },
+  plugins: [
+    nodeResolve({
+      jsnext: true
+    }),
+    babel({
+      exclude: 'node_modules/**'
+    }),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(env)
+    }),
+  ]
+};
+
+if (env === 'production') {
+  config.plugins.push(
+    uglify({
+      compress: {
+        pure_getters: true,
+        unsafe: true,
+        unsafe_comps: true,
+        warnings: false
+      }
+    })
+  );
+}
+
+export default config;

--- a/packages/redux-resource-action-creators/src/index.js
+++ b/packages/redux-resource-action-creators/src/index.js
@@ -1,0 +1,63 @@
+import {actionTypes} from 'redux-resource';
+import warning from './utils/warning';
+
+const _createAction = function(actionProperties = {}, actionDefaults = {}, type) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (actionProperties.type || actionDefaults.type) {
+      warning(
+        'It looks like you provided a `type` property for an action created using redux-resource-' +
+        'action-creators. This library sets the `type` for you; your value has been ignored. ' +
+        'For more, refer to the documentation: ' +
+        'https://redux-resource.js.org/docs/extras/redux-resource-action-creators.html'
+      );
+    }
+  }
+
+  return {
+    ...actionDefaults,
+    ...actionProperties,
+    type
+  };
+};
+
+const createActionCreators = (crudType, actionDefaults = {}) => {
+  const {resourceName} = actionDefaults;
+  const uppercaseCrud = typeof crudType === 'string' ? crudType.toUpperCase() : '';
+  const isValidCrudType =
+    uppercaseCrud === 'UPDATE' || uppercaseCrud === 'DELETE' ||
+    uppercaseCrud === 'READ' || uppercaseCrud === 'CREATE';
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (!isValidCrudType) {
+      warning(
+        `You supplied an invalid crudType of ${crudType} to createActionCreators.` +
+        `Please verify you've supplied one of: ['read', 'update', 'delete', 'create'].` +
+        'For more, refer to the documentation: ' +
+        'https://redux-resource.js.org/docs/extras/redux-resource-action-creators.html'
+      );
+    }
+
+    if (typeof resourceName !== 'string') {
+      warning(
+        `The value of "resourceName" that you passed to createActionCreators was ` +
+        `not a string. The resourceName must be a string. You should check ` +
+        `your redux-resource-action-creators configuration.` +
+        'For more, refer to the documentation: ' +
+        'https://redux-resource.js.org/docs/extras/redux-resource-action-creators.html'
+      );
+    }
+  }
+
+  return {
+    pending: (actionProperties) =>
+      _createAction(actionProperties, actionDefaults, actionTypes[`${uppercaseCrud}_RESOURCES_PENDING`]),
+    null: (actionProperties) =>
+      _createAction(actionProperties, actionDefaults, actionTypes[`${uppercaseCrud}_RESOURCES_NULL`]),
+    succeeded: (actionProperties) =>
+      _createAction(actionProperties, actionDefaults, actionTypes[`${uppercaseCrud}_RESOURCES_SUCCEEDED`]),
+    failed: (actionProperties) =>
+      _createAction(actionProperties, actionDefaults, actionTypes[`${uppercaseCrud}_RESOURCES_FAILED`]),
+  };
+};
+
+export default createActionCreators;

--- a/packages/redux-resource-action-creators/src/utils/warning.js
+++ b/packages/redux-resource-action-creators/src/utils/warning.js
@@ -1,0 +1,14 @@
+export default function warning(message) {
+  if (typeof console !== 'undefined' && typeof console.error === 'function') {
+    console.error(message);
+  }
+
+  try {
+    // This error was thrown as a convenience so that if you enable
+    // "break on all exceptions" in your console,
+    // it would pause the execution at this line.
+    throw new Error(message);
+  } catch (e) {
+    // Intentionally blank
+  }
+}

--- a/packages/redux-resource-action-creators/test/.eslintrc
+++ b/packages/redux-resource-action-creators/test/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "stub": true,
+    "expect": true
+  },
+  "rules": {
+    "prefer-arrow-callback": "off",
+    "max-nested-callbacks": "off",
+    "no-unused-expressions": "off"
+  }
+}

--- a/packages/redux-resource-action-creators/test/unit/redux-resource-action-creators.js
+++ b/packages/redux-resource-action-creators/test/unit/redux-resource-action-creators.js
@@ -1,0 +1,133 @@
+import {actionTypes} from 'redux-resource';
+import createActionCreators from '../../src';
+
+describe('Redux Resource Action Creators', function() {
+  beforeEach(() => {
+    this.consoleError = stub(console, 'error');
+  });
+
+  it('should export a function', () => {
+    expect(createActionCreators).to.be.a('function');
+  });
+
+  describe('Creating Action Creators', () => {
+    it('should not console.error when a valid resourceName & crudType are provided', () => {
+      createActionCreators('create', {resourceName: 'sandwiches'});
+      expect(this.consoleError.callCount).to.equal(0);
+    });
+
+    it('should console.error when no actionDefaults are passed', () => {
+      createActionCreators('create');
+      expect(this.consoleError.callCount).to.equal(1);
+    });
+
+    it('should console.error when a valid crudType is not provided', () => {
+      createActionCreators({resourceName: 'sandwiches'});
+      // Two warnings: one for no `crudType`, and one for no `resourceName`
+      expect(this.consoleError.callCount).to.equal(2);
+    });
+
+    it('should return an object with the expected action actionCreators methods', () => {
+      const actionCreators = createActionCreators('delete', {resourceName: 'sandwiches'});
+      expect(this.consoleError.callCount).to.equal(0);
+
+      expect(actionCreators.null).to.be.a('function');
+      expect(actionCreators.pending).to.be.a('function');
+      expect(actionCreators.succeeded).to.be.a('function');
+      expect(actionCreators.failed).to.be.a('function');
+    });
+  });
+
+  describe('pending()', () => {
+    it('should create an action with the expected action properties', () => {
+      this.actionCreators = createActionCreators('read', {
+        resourceName: 'sandwiches',
+      });
+
+      const action = this.actionCreators.pending({customProp: 'customValue'});
+
+      expect(action).to.deep.equal({
+        resourceName: 'sandwiches',
+        type: actionTypes.READ_RESOURCES_PENDING,
+        customProp: 'customValue'
+      });
+
+      expect(this.consoleError.callCount).to.equal(0);
+    });
+
+    it('should warn if type is provided, but ignore it', () => {
+      this.actionCreators = createActionCreators('read', {
+        resourceName: 'sandwiches',
+        type: 'oops'
+      });
+
+      const action = this.actionCreators.pending({customProp: 'customValue'});
+
+      expect(action).to.deep.equal({
+        resourceName: 'sandwiches',
+        type: actionTypes.READ_RESOURCES_PENDING,
+        customProp: 'customValue'
+      });
+
+      expect(this.consoleError.callCount).to.equal(1);
+    });
+  });
+
+  describe('null()', () => {
+    it('should create an action with the expected action properties', () => {
+      const actionCreators = createActionCreators('update', {
+        resourceName: 'sandwiches',
+      });
+
+      const action = actionCreators.null({customProp: 'customValue'});
+
+      expect(action).to.deep.equal({
+        resourceName: 'sandwiches',
+        type: actionTypes.UPDATE_RESOURCES_NULL,
+        customProp: 'customValue'
+      });
+
+      expect(this.consoleError.callCount).to.equal(0);
+    });
+  });
+
+  describe('succeeded()', () => {
+    it('should create an action with the expected action properties', () => {
+      const actionCreators = createActionCreators('create', {
+        resourceName: 'sandwiches',
+      });
+
+      const action = actionCreators.succeeded({
+        customProp: 'customValue',
+        resources: [{id: 1, type: 'pb&j'}, {id: 2, type: 'cuban'}]
+      });
+
+      expect(action).to.deep.equal({
+        resourceName: 'sandwiches',
+        type: actionTypes.CREATE_RESOURCES_SUCCEEDED,
+        customProp: 'customValue',
+        resources: [{id: 1, type: 'pb&j'}, {id: 2, type: 'cuban'}]
+      });
+
+      expect(this.consoleError.callCount).to.equal(0);
+    });
+  });
+
+  describe('failed()', () => {
+    it('should create an action with the expected action properties', () => {
+      const actionCreators = createActionCreators('delete', {
+        resourceName: 'sandwiches',
+      });
+
+      const action = actionCreators.failed({error: 'you should never delete sandwiches'});
+
+      expect(action).to.deep.equal({
+        resourceName: 'sandwiches',
+        type: actionTypes.DELETE_RESOURCES_FAILED,
+        error: 'you should never delete sandwiches'
+      });
+
+      expect(this.consoleError.callCount).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
Implements the discussion and API in #186 that can be leveraged in both plugins & applications using `redux-resource` to help create valid action shapes for our ecosystem.

Published: `redux-resource-action-creators@1.0.0-alpha.1` so we can try it out in apps and take a look at how this API works in practice after the bikeshedding that produced it ;)