### PR TITLE
Remove outdated caveat in docs

### DIFF
--- a/docs/api-reference/get-status.md
+++ b/docs/api-reference/get-status.md
@@ -53,10 +53,6 @@ your state tree. For instance `"books.meta.24.readStatus"` or
 
 > Keep in mind that `treatNullAsPending` also works when aggregating.
 
-A limitation of `getStatus` is that it does not support paths that contain periods
-in the object keys. For more, refer to
-[gh-166](https://github.com/jmeas/redux-resource/issues/166).
-
 #### Examples
 
 In this example, we pass a single status location:


### PR DESCRIPTION
Looks like this was closed by https://github.com/jmeas/redux-resource/pull/234

There's not much guidance about dots in paths at this point - I suppose the sentence could be updated rather than deleted.