### PR TITLE
Bugfix id checks

### DIFF
--- a/packages/redux-resource/src/request-statuses-plugin/delete.js
+++ b/packages/redux-resource/src/request-statuses-plugin/delete.js
@@ -48,7 +48,7 @@ function delSucceed(state, action, {initialResourceMeta}) {
     idList = resources.map(r => {
       if (typeof r === 'object') {
         if (process.env.NODE_ENV !== 'production') {
-          if (!r.id || (typeof r.id !== 'string' && typeof r.id !== 'number')) {
+          if ((!r.id && r.id !== 0) || (typeof r.id !== 'string' && typeof r.id !== 'number')) {
             warning(
               `A resource without an ID was passed to an action with type ` +
               `${action.type}. Every resource must have an ID that is either ` +

--- a/packages/redux-resource/src/utils/set-resource-meta.js
+++ b/packages/redux-resource/src/utils/set-resource-meta.js
@@ -26,7 +26,7 @@ export default function setResourceMeta(options) {
     // the user with meta **and** attribute update problems. If the ID check
     // is moved into the success reducers directly, then we may be able to
     // remove these typeof checks for efficiency.
-    if (!id || (typeof id !== 'string' && typeof id !== 'number')) {
+    if ((!id && id !== 0) || (typeof id !== 'string' && typeof id !== 'number')) {
       return;
     }
 

--- a/packages/redux-resource/src/utils/upsert-resources.js
+++ b/packages/redux-resource/src/utils/upsert-resources.js
@@ -15,7 +15,7 @@ export default function upsertResources(resources, newResources, mergeResources)
     const id = resourceIsObject ? resource.id : resource;
 
     // If a resource doesn't have an ID, then it cannot be tracked
-    if (!id) {
+    if (!id && id !== 0) {
       if (process.env.NODE_ENV !== 'production') {
         warning(
           `You attempted to update or add a resource without an ID attribute. ` +

--- a/packages/redux-resource/test/unit/reducers/delete.js
+++ b/packages/redux-resource/test/unit/reducers/delete.js
@@ -232,6 +232,68 @@ describe('reducers: delete', function() {
       expect(console.error.callCount).to.equal(0);
     });
 
+    it('returns the right state without a request name, with IDs, including an ID of the number 0 (gh-298)', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            0: {id: 0},
+            3: {id: 3},
+            4: {id: 4},
+          },
+          lists: {},
+          requests: {},
+          meta: {
+            0: {
+              name: 'what'
+            },
+            3: {
+              deleteStatus: 'sandwiches'
+            }
+          }
+        },
+        initialResourceMeta: {
+          selected: false
+        }
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'DELETE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        resources: [0, {id: 4}]
+      });
+
+      expect(reduced).to.deep.equal({
+        resources: {
+          0: null,
+          3: {id: 3},
+          4: null
+        },
+        lists: {},
+        requests: {},
+        meta: {
+          0: {
+            selected: false,
+            createStatus: requestStatuses.NULL,
+            readStatus: requestStatuses.NULL,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.SUCCEEDED
+          },
+          3: {
+            deleteStatus: 'sandwiches'
+          },
+          4: {
+            selected: false,
+            createStatus: requestStatuses.NULL,
+            readStatus: requestStatuses.NULL,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.SUCCEEDED
+          }
+        }
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+
     it('warns and ignores a poorly-formatted request name', () => {
       stub(console, 'error');
       const reducer = resourceReducer('hellos', {

--- a/packages/redux-resource/test/unit/utils/set-resource-meta.js
+++ b/packages/redux-resource/test/unit/utils/set-resource-meta.js
@@ -170,4 +170,18 @@ describe('setResourceMeta', function() {
       expect(result[3]).to.equal(this.meta[3]);
     });
   });
+
+  describe('update resource meta', () => {
+    it('should perform updates for any valid resource ids (gh-298)', () => {
+      const result = setResourceMeta({
+        meta: {},
+        newMeta: {updated: true},
+        resources: [0, '', {id: false}, 1, 2, 3, '1234'],
+      });
+
+      expect(result).to.have.property('0');
+      expect(result[0]).to.eql({updated: true});
+      expect(result).to.not.have.property('false');
+    });
+  });
 });

--- a/packages/redux-resource/test/unit/utils/set-resource-meta.js
+++ b/packages/redux-resource/test/unit/utils/set-resource-meta.js
@@ -172,16 +172,30 @@ describe('setResourceMeta', function() {
   });
 
   describe('update resource meta', () => {
-    it('should perform updates for any valid resource ids (gh-298)', () => {
+    it('should perform updates for IDs that are the number 0 (gh-298)', () => {
       const result = setResourceMeta({
         meta: {},
         newMeta: {updated: true},
         resources: [0, '', {id: false}, 1, 2, 3, '1234'],
       });
 
-      expect(result).to.have.property('0');
-      expect(result[0]).to.eql({updated: true});
-      expect(result).to.not.have.property('false');
+      expect(result).to.deep.equal({
+        0: {
+          updated: true
+        },
+        1: {
+          updated: true,
+        },
+        2: {
+          updated: true,
+        },
+        3: {
+          updated: true,
+        },
+        1234: {
+          updated: true,
+        },
+      });
     });
   });
 });

--- a/packages/redux-resource/test/unit/utils/upsert-resources.js
+++ b/packages/redux-resource/test/unit/utils/upsert-resources.js
@@ -20,6 +20,16 @@ describe('upsertResources', function() {
     expect(console.error.callCount).to.equal(1);
   });
 
+  it('should not warn when a resource with an ID of 0 is passed', () => {
+    stub(console, 'error');
+
+    upsertResources(this.resources, [
+      {id: 0}
+    ]);
+
+    expect(console.error.callCount).to.equal(0);
+  });
+
   it('should accept an empty array of newResources', () => {
     const nullResult = upsertResources(this.resources, null);
     expect(nullResult).to.equal(this.resources);


### PR DESCRIPTION
First pass at resolving #298, I started with a simple test to show that resources with `0` for an ID value were not being parsed. I had to change the checks a bit due to some changes made for #118 and hopefully am still covering enough cases here. Feedback welcome!