### PR TITLE
Rename resourceName to resourceType

### DIFF
--- a/docs/api-reference/action-types.md
+++ b/docs/api-reference/action-types.md
@@ -50,7 +50,7 @@ export default function readBook(bookId) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.READ_RESOURCES_PENDING,
-      resourceName: 'books'
+      resourceType: 'books'
       resources: [bookId]
     });
 
@@ -58,19 +58,19 @@ export default function readBook(bookId) {
       if (req.aborted) {
         dispatch({
           type: actionTypes.READ_RESOURCES_IDLE,
-          resourceName: 'books',
+          resourceType: 'books',
           resources: [bookId]
         });
       } else if (err || res.statusCode >= 400) {
         dispatch({
           type: actionTypes.READ_RESOURCES_FAILED,
-          resourceName: 'books',
+          resourceType: 'books',
           resources: [bookId]
         });
       } else {
         dispatch({
           type: actionTypes.READ_RESOURCES_SUCCEEDED,
-          resourceName: 'books',
+          resourceType: 'books',
           resources: [res.body]
         });
       }

--- a/docs/api-reference/resource-reducer.md
+++ b/docs/api-reference/resource-reducer.md
@@ -1,4 +1,4 @@
-# `resourceReducer(resourceName, [options])`
+# `resourceReducer(resourceType, [options])`
 
 Creates a Redux [reducer](http://redux.js.org/docs/basics/Reducers.html) that
 changes your store's state when actions with one of the CRUD
@@ -6,9 +6,9 @@ changes your store's state when actions with one of the CRUD
 
 #### Arguments
 
-1. `resourceName` *(String)*: The name of your resource. Typically, you'll want
-  to use a plural name. For instance, "books," rather than "book." You should
-  also use this as the name of your store slice when using
+1. `resourceType` *(String)*: The type of your resource. Typically, you'll want
+  to use a plural type. For instance, "books," rather than "book." You should
+  also use this as the key of your store slice when using
   [combineReducers](http://redux.js.org/docs/api/combineReducers.html), for
   consistency.
 

--- a/docs/extras/http-status-codes-plugin.md
+++ b/docs/extras/http-status-codes-plugin.md
@@ -37,7 +37,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_FAILED,
-  resourceName: 'books',
+  resourceType: 'books',
   resources: [10],
   statusCode: 404
 });

--- a/docs/extras/included-resources-plugin.md
+++ b/docs/extras/included-resources-plugin.md
@@ -42,7 +42,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
-  resourceName: 'authors',
+  resourceType: 'authors',
   resources: [{
     id: 10,
     name: 'Sarah'

--- a/docs/extras/redux-resource-action-creators.md
+++ b/docs/extras/redux-resource-action-creators.md
@@ -38,7 +38,7 @@ This library has a single export, `createActionCreators`.
 
 2. `actionDefaults` *(Object)*: Properties that will be included on each dispatched
     action. The [the CRUD Action guide](/docs/guides/crud-actions.md) lists possible
-    options, such as `resourceName` and `resources`. You *must* include `resourceName`.
+    options, such as `resourceType` and `resources`. You *must* include `resourceType`.
 
 #### Returns
 
@@ -53,7 +53,7 @@ import createActionCreators from 'redux-resource-action-creators';
 import store from './store';
 
 const readActionCreators = createActionCreators('read', {
-  resourceName: 'books',
+  resourceType: 'books',
   request: 'getHomePageBooks',
   list: 'homePageBooks',
   mergeListIds: false
@@ -83,7 +83,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books',
+  resourceType: 'books',
   request: 'getHomePageBooks',
   list: 'homePageBooks'
 });
@@ -92,21 +92,21 @@ const req = fetchData((err, res, body) => {
   if (req.aborted) {
     store.dispatch({
       type: actionTypes.READ_RESOURCES_NULL,
-      resourceName: 'books',
+      resourceType: 'books',
       request: 'getHomePageBooks',
       list: 'homePageBooks'
     });
   } else if (err) {
     store.dispatch({
       type: actionTypes.READ_RESOURCES_FAILED,
-      resourceName: 'books',
+      resourceType: 'books',
       request: 'getHomePageBooks',
       list: 'homePageBooks'
     });
   } else {
     store.dispatch(readActionCreators.succeeded({
       type: actionTypes.READ_RESOURCES_SUCCEEDED,
-      resourceName: 'books',
+      resourceType: 'books',
       request: 'getHomePageBooks',
       list: 'homePageBooks',
       resources: body
@@ -123,7 +123,7 @@ import { actionTypes } from 'redux-resource';
 import store from './store';
 
 const actionDefaults = {
-  resourceName: 'books',
+  resourceType: 'books',
   request: 'getHomePageBooks',
   list: 'homePageBooks'
 };

--- a/docs/extras/redux-resource-xhr.md
+++ b/docs/extras/redux-resource-xhr.md
@@ -53,7 +53,7 @@ An action creator for CRUD requests.
 
   * `actionDefaults`: *(Object)* Properties that will be included on each dispatched
     action. All of [the CRUD Action options](/docs/guides/crud-actions.md) are
-    supported, such as `resourceName` and `resources`.
+    supported, such as `resourceType` and `resources`.
 
   * `dispatch`: *(Function)* The `dispatch` function of a Redux store. If you're using
     [`redux-thunk`]((https://github.com/gaearon/redux-thunk)), this will be the first
@@ -120,7 +120,7 @@ const xhrOptions = {
 const xhr = crudRequest('read', {
   dispatch: store.dispatch,
   actionDefaults: {
-    resourceName: 'books',
+    resourceType: 'books',
     request: 'getHomePageBooks',
     list: 'homePageBooks',
     mergeListIds: false
@@ -237,7 +237,7 @@ xhr.get('/books/24')
 
       return crudRequest('read', {
         actionDefaults: {
-          resourceName: 'books',
+          resourceType: 'books',
           request: 'getHomePageBooks',
           list: 'homePageBooks',
           mergeListIds: false,

--- a/docs/extras/reset-plugin.md
+++ b/docs/extras/reset-plugin.md
@@ -68,9 +68,9 @@ store.dispatch(reset.resetResource('books', {
 
 ---
 
-### `resetResource(resourceName, [options])`
+### `resetResource(resourceType, [options])`
 
-Resets the slice for `resourceName`. Pass `options` to scope what's reset.
+Resets the slice for `resourceType`. Pass `options` to scope what's reset.
 There are two valid options:
 
 - `request`: Reset the request with this name
@@ -78,7 +78,7 @@ There are two valid options:
 
 #### Arguments
 
-1. `resourceName` *(String)*: The name of the slice to reset.
+1. `resourceType` *(String)*: The name of the slice to reset.
 
 2. [`options`] *(String)*: Options to scope what is reset.
 

--- a/docs/extras/selection-plugin.md
+++ b/docs/extras/selection-plugin.md
@@ -80,14 +80,14 @@ deleteBooks(books.selectedIds);
 
 ---
 
-### `selectResources(resourceName, resources)`
+### `selectResources(resourceType, resources)`
 
-Selects `resources` for slice `resourceName`. Resources that are already
+Selects `resources` for slice `resourceType`. Resources that are already
 selected will be ignored.
 
 #### Arguments
 
-1. `resourceName` *(String)*: The name of the slice to select resources from.
+1. `resourceType` *(String)*: The name of the slice to select resources from.
 
 2. `resources` *(Array)*: An array of resources, or resource IDs, to be
   selected.
@@ -98,14 +98,14 @@ selected will be ignored.
 
 ---
 
-### `deselectResources(resourceName, resources)`
+### `deselectResources(resourceType, resources)`
 
-Deselects `resources` for slice `resourceName`. Resources that aren't selected
+Deselects `resources` for slice `resourceType`. Resources that aren't selected
 will be ignored.
 
 #### Arguments
 
-1. `resourceName` *(String)*: The name of the slice to deselect resources from.
+1. `resourceType` *(String)*: The name of the slice to deselect resources from.
 
 2. `resources` *(Array)*: An array of resources, or resource IDs, to deselect.
 
@@ -115,13 +115,13 @@ will be ignored.
 
 ---
 
-### `clearSelectedResources(resourceName)`
+### `clearSelectedResources(resourceType)`
 
-Deselects every resource for slice `resourceName`.
+Deselects every resource for slice `resourceType`.
 
 #### Arguments
 
-1. `resourceName` *(String)*: The name of the slice to clear the selected
+1. `resourceType` *(String)*: The name of the slice to clear the selected
   resources from.
 
 #### Returns

--- a/docs/guides/creating-resources.md
+++ b/docs/guides/creating-resources.md
@@ -64,7 +64,7 @@ export default function createBook(bookDetails) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.CREATE_RESOURCES_PENDING,
-      resourceName: 'books',
+      resourceType: 'books',
       request: 'create'
     });
 
@@ -77,19 +77,19 @@ export default function createBook(bookDetails) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.CREATE_RESOURCES_IDLE,
-            resourceName: 'books',
+            resourceType: 'books',
             request: 'create'
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.CREATE_RESOURCES_FAILED,
-            resourceName: 'books',
+            resourceType: 'books',
             request: 'create'
           });
         } else {
           dispatch({
             type: actionTypes.CREATE_RESOURCES_SUCCEEDED,
-            resourceName: 'books',
+            resourceType: 'books',
             request: 'create',
             resources: [body]
           });

--- a/docs/guides/crud-actions.md
+++ b/docs/guides/crud-actions.md
@@ -25,7 +25,7 @@ recommended for making action creators for these CRUD operations.
 
 ### Action Attributes
 
-All actions have a single required value, `resourceName`, which is the name
+All actions have a single required value, `resourceType`, which is the name
 of the resource that is being affected. The simplest action, then, looks
 something like this:
 
@@ -35,7 +35,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books'
+  resourceType: 'books'
 });
 ```
 
@@ -94,7 +94,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books',
+  resourceType: 'books',
   resources: [23]
 });
 ```
@@ -109,7 +109,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
-  resourceName: 'books',
+  resourceType: 'books',
   resources: [{
     id: 23,
     releaseYear: 2015,
@@ -149,7 +149,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books',
+  resourceType: 'books',
   request: 'booksSearch',
 
   // You may also includes additional attributes on a request.
@@ -178,7 +178,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books',
+  resourceType: 'books',
   list: 'mostPopular',
   request: 'getMostPopular',
   query: 'Lord of the Flies'

--- a/docs/guides/deleting-resources.md
+++ b/docs/guides/deleting-resources.md
@@ -71,7 +71,7 @@ export default function deleteBook(bookId) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.DELETE_RESOURCES_PENDING,
-      resourceName: 'books',
+      resourceType: 'books',
       resources: [bookId]
     });
 
@@ -81,19 +81,19 @@ export default function deleteBook(bookId) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.DELETE_RESOURCES_IDLE,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookId]
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.DELETE_RESOURCES_FAILED,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookId]
           });
         } else {
           dispatch({
             type: actionTypes.DELETE_RESOURCES_SUCCEEDED,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookId]
           });
         }

--- a/docs/guides/lists.md
+++ b/docs/guides/lists.md
@@ -21,7 +21,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
-  resourceName: 'books',
+  resourceType: 'books',
   list: 'mostPopular',
   // Remember, we always want to track the request status
   request: 'getMostPopular'
@@ -99,7 +99,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
-  resourceName: 'books',
+  resourceType: 'books',
   list: 'mostPopular',
   mergeListIds: false,
   // `newResources` is the list of books that were returned by the server

--- a/docs/guides/named-requests.md
+++ b/docs/guides/named-requests.md
@@ -42,7 +42,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books',
+  resourceType: 'books',
   request: 'search'
 });
 ```
@@ -103,7 +103,7 @@ import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
-  resourceName: 'books',
+  resourceType: 'books',
   request: 'search',
   // `newResources` are the list of books that were returned by the server
   // for this query.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -62,10 +62,10 @@ export default resourceReducer('books', {
 A plugin is a function that with the following signature:
 
 ```js
-(resourceName, options) => reducerFunction
+(resourceType, options) => reducerFunction
 ```
 
-Where `resourceName` and `options` are the same values that you passed to
+Where `resourceType` and `options` are the same values that you passed to
 [`resourceReducer`](/docs/api-reference/resource-reducer.md).
 
 The return value, `reducerFunction`, is also a function. This returned function
@@ -81,7 +81,7 @@ reducer and `action` is the action that was dispatched.
 The simplest plugin then (which doesn't do anything), would look like this:
 
 ```js
-function myPlugin(resourceName, options) {
+function myPlugin(resourceType, options) {
   return function(state, action) {
     return state;
   }
@@ -91,7 +91,7 @@ function myPlugin(resourceName, options) {
 If you prefer using arrow functions, you might choose to write this like so:
 
 ```js
-const myPlugin = (resourceName, option) => (state, action) => state;
+const myPlugin = (resourceType, option) => (state, action) => state;
 ```
 
 This plugin isn't very exciting, so let's look at more realistic examples.
@@ -105,10 +105,10 @@ for this plugin looks like this:
 import { setResourceMeta } from 'redux-resource';
 import myActionTypes from './my-action-types';
 
-export default function(resourceName, options) {
+export default function(resourceType, options) {
   return function(state, action) {
     // Ignore actions that were dispatched for another resource type
-    if (action.resourceName !== resourceName) {
+    if (action.resourceType !== resourceType) {
       return state;
     }
 
@@ -169,11 +169,11 @@ the following plugin, we set a property on the store anytime a successful read
 occurs:
 
 ```js
-export default function(resourceName, options) {
+export default function(resourceType, options) {
   return function(state, action) {
     // Only take action if the resource name of the Action matches the
     // resource this plugin is registered for
-    if (action.resourceName !== resourceName) {
+    if (action.resourceType !== resourceType) {
       return state;
     }
 
@@ -196,7 +196,7 @@ the fact that the `resourceReducer`'s options are passed into plugins. For
 instance, if you had a plugin like the following:
 
 ```js
-export default function customizablePlugin(resourceName, options) {
+export default function customizablePlugin(resourceType, options) {
   return function(state, action) {
     if (options.useSpecialBehavior) {
       // Perform a computation
@@ -225,7 +225,7 @@ in a function, like so:
 
 ```js
 export default function(pluginOptions) {
-  return function customizablePlugin(resourceName, options) {
+  return function customizablePlugin(resourceType, options) {
     return function(state, action) {
       if (pluginOptions.useSpecialBehavior) {
         // Perform a computation

--- a/docs/guides/reading-resources.md
+++ b/docs/guides/reading-resources.md
@@ -64,7 +64,7 @@ export default function readBook(bookId) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.READ_RESOURCES_PENDING,
-      resourceName: 'books',
+      resourceType: 'books',
       resources: [bookId]
     });
 
@@ -75,19 +75,19 @@ export default function readBook(bookId) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.READ_RESOURCES_IDLE,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookId]
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.READ_RESOURCES_FAILED,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookId]
           });
         } else {
           dispatch({
             type: actionTypes.READ_RESOURCES_SUCCEEDED,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [body]
           });
         }
@@ -116,7 +116,7 @@ export default function readBooks(query) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.READ_RESOURCES_PENDING,
-      resourceName: 'books',
+      resourceType: 'books',
       request: 'search'
     });
 
@@ -129,19 +129,19 @@ export default function readBooks(query) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.READ_RESOURCES_IDLE,
-            resourceName: 'books',
+            resourceType: 'books',
             request: 'search'
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.READ_RESOURCES_FAILED,
-            resourceName: 'books',
+            resourceType: 'books',
             request: 'search'
           });
         } else {
           dispatch({
             type: actionTypes.READ_RESOURCES_SUCCEEDED,
-            resourceName: 'books',
+            resourceType: 'books',
             request: 'search',
             resources: body
           });

--- a/docs/guides/tracking-requests.md
+++ b/docs/guides/tracking-requests.md
@@ -28,7 +28,7 @@ of a book with ID 24 looks like the following:
 ```js
 {
   type: actionTypes.READ_RESOURCES_PENDING,
-  resourceName: 'books',
+  resourceType: 'books',
   resources: [24]
 }
 ```

--- a/docs/guides/updating-resources.md
+++ b/docs/guides/updating-resources.md
@@ -67,7 +67,7 @@ export default function updateBook(bookDetails) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.UPDATE_RESOURCES_PENDING,
-      resourceName: 'books',
+      resourceType: 'books',
       // You can pass either the whole `bookDetails`, or just the ID. Both work.
       // Just be sure to pass the whole object on success, so that the updated
       // attributes are persisted to your state tree!
@@ -83,19 +83,19 @@ export default function updateBook(bookDetails) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.UPDATE_RESOURCES_IDLE,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookDetails.id]
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.UPDATE_RESOURCES_FAILED,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [bookDetails.id]
           });
         } else {
           dispatch({
             type: actionTypes.UPDATE_RESOURCES_SUCCEEDED,
-            resourceName: 'books',
+            resourceType: 'books',
             resources: [body]
           });
         }

--- a/docs/recipes/related-resources.md
+++ b/docs/recipes/related-resources.md
@@ -64,9 +64,9 @@ const normalizedData = normalize(originalData, [article]);
 
 const action = {
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
-  // We recommend that you use the same string for the `resourceName`, resource slice,
+  // We recommend that you use the same string for the `resourceType`, resource slice,
   // and normalizr key.
-  resourceName: article.key,
+  resourceType: article.key,
   resources: normalizedData.result,
   includedResources: normalizedData.entities
 };
@@ -93,7 +93,7 @@ export function readAuthor(authorId) {
     dispatch,
     xhrOptions,
     actionDefaults: {
-      resourceName: 'authors',
+      resourceType: 'authors',
       resources: [authorId]
     },
     onSucceeded(action, res, body) {
@@ -123,7 +123,7 @@ In short, you would need to interpet the `included` member of a
 would likely work in 2 steps:
 
 1. Filter the Array of `included` resources to find _just_ the resources whose
-  JSON API `type` matches the `resourceName` of the slice.
+  JSON API `type` matches the `resourceType` of the slice.
 2. Use [`upsertResources`](/docs/api-reference/upsert-resources.md) to add those resources to the slice.
 
 You would also want to place the each individual resource's `meta` into the `meta` section of the

--- a/docs/recipes/unauthorized-responses.md
+++ b/docs/recipes/unauthorized-responses.md
@@ -38,7 +38,7 @@ export function readBook(id) {
   return function(dispatch) {
     dispatch({
       type: actionTypes.READ_RESOURCES_PENDING,
-      resourceName: 'books',
+      resourceType: 'books',
       resources: [id]
     });
 
@@ -46,7 +46,7 @@ export function readBook(id) {
       if (err || res.statusCode >= 400) {
         dispatch({
           type: actionTypes.READ_RESOURCES_FAILED,
-          resourceName: 'books',
+          resourceType: 'books',
           resources: [id],
           res
         });

--- a/packages/redux-resource-action-creators/src/index.js
+++ b/packages/redux-resource-action-creators/src/index.js
@@ -20,12 +20,13 @@ const _createAction = function(
   return {
     ...actionDefaults,
     ...actionProperties,
-    type
+    type,
   };
 };
 
 const createActionCreators = (crudType, actionDefaults = {}) => {
-  const { resourceName } = actionDefaults;
+  const { resourceName, resourceType } = actionDefaults;
+  const typeToUse = resourceType || resourceName;
   const uppercaseCrud =
     typeof crudType === 'string' ? crudType.toUpperCase() : '';
   const isValidCrudType =
@@ -44,10 +45,10 @@ const createActionCreators = (crudType, actionDefaults = {}) => {
       );
     }
 
-    if (typeof resourceName !== 'string') {
+    if (typeof typeToUse !== 'string') {
       warning(
-        `The value of "resourceName" that you passed to createActionCreators was ` +
-          `not a string. The resourceName must be a string. You should check ` +
+        `The value of "resourceType" that you passed to createActionCreators was ` +
+          `not a string. The resourceType must be a string. You should check ` +
           `your redux-resource-action-creators configuration.` +
           'For more, refer to the documentation: ' +
           'https://redux-resource.js.org/docs/extras/redux-resource-action-creators.html'
@@ -79,7 +80,7 @@ const createActionCreators = (crudType, actionDefaults = {}) => {
         actionProperties,
         actionDefaults,
         actionTypes[`${uppercaseCrud}_RESOURCES_FAILED`]
-      )
+      ),
   };
 };
 

--- a/packages/redux-resource-action-creators/test/unit/redux-resource-action-creators.js
+++ b/packages/redux-resource-action-creators/test/unit/redux-resource-action-creators.js
@@ -11,8 +11,8 @@ describe('Redux Resource Action Creators', function() {
   });
 
   describe('Creating Action Creators', () => {
-    it('should not console.error when a valid resourceName & crudType are provided', () => {
-      createActionCreators('create', { resourceName: 'sandwiches' });
+    it('should not console.error when a valid resourceType & crudType are provided', () => {
+      createActionCreators('create', { resourceType: 'sandwiches' });
       expect(this.consoleError.callCount).to.equal(0);
     });
 
@@ -22,14 +22,14 @@ describe('Redux Resource Action Creators', function() {
     });
 
     it('should console.error when a valid crudType is not provided', () => {
-      createActionCreators({ resourceName: 'sandwiches' });
-      // Two warnings: one for no `crudType`, and one for no `resourceName`
+      createActionCreators({ resourceType: 'sandwiches' });
+      // Two warnings: one for no `crudType`, and one for no `resourceType`
       expect(this.consoleError.callCount).to.equal(2);
     });
 
     it('should return an object with the expected action actionCreators methods', () => {
       const actionCreators = createActionCreators('delete', {
-        resourceName: 'sandwiches'
+        resourceType: 'sandwiches',
       });
       expect(this.consoleError.callCount).to.equal(0);
 
@@ -43,15 +43,15 @@ describe('Redux Resource Action Creators', function() {
   describe('pending()', () => {
     it('should create an action with the expected action properties', () => {
       this.actionCreators = createActionCreators('read', {
-        resourceName: 'sandwiches'
+        resourceType: 'sandwiches',
       });
 
       const action = this.actionCreators.pending({ customProp: 'customValue' });
 
       expect(action).to.deep.equal({
-        resourceName: 'sandwiches',
+        resourceType: 'sandwiches',
         type: actionTypes.READ_RESOURCES_PENDING,
-        customProp: 'customValue'
+        customProp: 'customValue',
       });
 
       expect(this.consoleError.callCount).to.equal(0);
@@ -59,16 +59,16 @@ describe('Redux Resource Action Creators', function() {
 
     it('should warn if type is provided, but ignore it', () => {
       this.actionCreators = createActionCreators('read', {
-        resourceName: 'sandwiches',
-        type: 'oops'
+        resourceType: 'sandwiches',
+        type: 'oops',
       });
 
       const action = this.actionCreators.pending({ customProp: 'customValue' });
 
       expect(action).to.deep.equal({
-        resourceName: 'sandwiches',
+        resourceType: 'sandwiches',
         type: actionTypes.READ_RESOURCES_PENDING,
-        customProp: 'customValue'
+        customProp: 'customValue',
       });
 
       expect(this.consoleError.callCount).to.equal(1);
@@ -78,15 +78,15 @@ describe('Redux Resource Action Creators', function() {
   describe('null()', () => {
     it('should create an action with the expected action properties', () => {
       const actionCreators = createActionCreators('update', {
-        resourceName: 'sandwiches'
+        resourceType: 'sandwiches',
       });
 
       const action = actionCreators.null({ customProp: 'customValue' });
 
       expect(action).to.deep.equal({
-        resourceName: 'sandwiches',
+        resourceType: 'sandwiches',
         type: actionTypes.UPDATE_RESOURCES_NULL,
-        customProp: 'customValue'
+        customProp: 'customValue',
       });
 
       expect(this.consoleError.callCount).to.equal(0);
@@ -96,19 +96,19 @@ describe('Redux Resource Action Creators', function() {
   describe('succeeded()', () => {
     it('should create an action with the expected action properties', () => {
       const actionCreators = createActionCreators('create', {
-        resourceName: 'sandwiches'
+        resourceType: 'sandwiches',
       });
 
       const action = actionCreators.succeeded({
         customProp: 'customValue',
-        resources: [{ id: 1, type: 'pb&j' }, { id: 2, type: 'cuban' }]
+        resources: [{ id: 1, type: 'pb&j' }, { id: 2, type: 'cuban' }],
       });
 
       expect(action).to.deep.equal({
-        resourceName: 'sandwiches',
+        resourceType: 'sandwiches',
         type: actionTypes.CREATE_RESOURCES_SUCCEEDED,
         customProp: 'customValue',
-        resources: [{ id: 1, type: 'pb&j' }, { id: 2, type: 'cuban' }]
+        resources: [{ id: 1, type: 'pb&j' }, { id: 2, type: 'cuban' }],
       });
 
       expect(this.consoleError.callCount).to.equal(0);
@@ -118,17 +118,17 @@ describe('Redux Resource Action Creators', function() {
   describe('failed()', () => {
     it('should create an action with the expected action properties', () => {
       const actionCreators = createActionCreators('delete', {
-        resourceName: 'sandwiches'
+        resourceType: 'sandwiches',
       });
 
       const action = actionCreators.failed({
-        error: 'you should never delete sandwiches'
+        error: 'you should never delete sandwiches',
       });
 
       expect(action).to.deep.equal({
-        resourceName: 'sandwiches',
+        resourceType: 'sandwiches',
         type: actionTypes.DELETE_RESOURCES_FAILED,
-        error: 'you should never delete sandwiches'
+        error: 'you should never delete sandwiches',
       });
 
       expect(this.consoleError.callCount).to.equal(0);

--- a/packages/redux-resource-plugins/src/http-status-codes.js
+++ b/packages/redux-resource-plugins/src/http-status-codes.js
@@ -28,9 +28,10 @@ const deleteEndActions = [
 
 // This sets a new meta property on resource and request metadata: `statusCode`.
 // This will be equal to the last status code for a request
-export default function httpStatusCodes(resourceName) {
+export default function httpStatusCodes(resourceType) {
   return function(state, action) {
-    if (action.resourceName !== resourceName) {
+    const typeToCheck = action.resourceType || action.resourceName;
+    if (typeToCheck !== resourceType) {
       return state;
     }
 

--- a/packages/redux-resource-plugins/src/included-resources.js
+++ b/packages/redux-resource-plugins/src/included-resources.js
@@ -2,12 +2,12 @@ import {
   upsertResources,
   setResourceMeta,
   requestStatuses,
-  actionTypes
+  actionTypes,
 } from 'redux-resource';
 
 // This plugin adds support for "compound documents," or including multiple
 // resource types in a single action.
-export default function includedResources(resourceName, options = {}) {
+export default function includedResources(resourceType, options = {}) {
   return (state, action) => {
     const { initialResourceMeta } = options;
     const { includedResources, mergeMeta, mergeResources, type } = action;
@@ -23,7 +23,7 @@ export default function includedResources(resourceName, options = {}) {
     }
 
     // If there are no included resources for this slice, then we do nothing
-    const includedResourceList = includedResources[resourceName];
+    const includedResourceList = includedResources[resourceType];
 
     if (!includedResourceList) {
       return state;
@@ -39,16 +39,16 @@ export default function includedResources(resourceName, options = {}) {
       resources: includedResourceList,
       meta: state.meta,
       newMeta: {
-        readStatus: requestStatuses.SUCCEEDED
+        readStatus: requestStatuses.SUCCEEDED,
       },
       initialResourceMeta,
-      mergeMeta
+      mergeMeta,
     });
 
     return {
       ...state,
       meta,
-      resources
+      resources,
     };
   };
 }

--- a/packages/redux-resource-plugins/src/reset.js
+++ b/packages/redux-resource-plugins/src/reset.js
@@ -1,23 +1,24 @@
 import { requestStatuses } from 'redux-resource';
 
 const actionTypes = {
-  RESET_RESOURCE: 'RESET_RESOURCE'
+  RESET_RESOURCE: 'RESET_RESOURCE',
 };
 
-function resetResource(resourceName, { request, list } = {}) {
+function resetResource(resourceType, { request, list } = {}) {
   return {
     type: 'RESET_RESOURCE',
-    resourceName,
+    resourceType,
     request,
-    list
+    list,
   };
 }
 
-function reset(resourceName, options = {}) {
+function reset(resourceType, options = {}) {
   return function(state, action) {
+    const typeToUse = action.resourceType || action.resourceName;
     if (
       action.type !== actionTypes.RESET_RESOURCE ||
-      action.resourceName !== resourceName
+      typeToUse !== resourceType
     ) {
       return state;
     }
@@ -30,12 +31,12 @@ function reset(resourceName, options = {}) {
         meta: {},
         lists: {},
         requests: {},
-        ...options.initialState
+        ...options.initialState,
       };
     }
 
     const newState = {
-      ...state
+      ...state,
     };
 
     if (request) {
@@ -43,15 +44,15 @@ function reset(resourceName, options = {}) {
         ...state.requests,
         [request]: {
           ids: [],
-          status: requestStatuses.IDLE
-        }
+          status: requestStatuses.IDLE,
+        },
       };
     }
 
     if (list) {
       newState.lists = {
         ...state.lists,
-        [list]: []
+        [list]: [],
       };
     }
 

--- a/packages/redux-resource-plugins/src/selection.js
+++ b/packages/redux-resource-plugins/src/selection.js
@@ -1,40 +1,41 @@
 const actionTypes = {
   SELECT_RESOURCES: 'SELECT_RESOURCES',
   DESELECT_RESOURCES: 'DESELECT_RESOURCES',
-  CLEAR_SELECTED_RESOURCES: 'CLEAR_SELECTED_RESOURCES'
+  CLEAR_SELECTED_RESOURCES: 'CLEAR_SELECTED_RESOURCES',
 };
 
 const initialState = {
-  selectedIds: []
+  selectedIds: [],
 };
 
-function selectResources(resourceName, resources) {
+function selectResources(resourceType, resources) {
   return {
     type: actionTypes.SELECT_RESOURCES,
-    resourceName,
-    resources
+    resourceType,
+    resources,
   };
 }
 
-function deselectResources(resourceName, resources) {
+function deselectResources(resourceType, resources) {
   return {
     type: actionTypes.DESELECT_RESOURCES,
-    resourceName,
-    resources
+    resourceType,
+    resources,
   };
 }
 
-function clearSelectedResources(resourceName) {
+function clearSelectedResources(resourceType) {
   return {
     type: actionTypes.CLEAR_SELECTED_RESOURCES,
-    resourceName
+    resourceType,
   };
 }
 
-function selection(resourceName) {
+function selection(resourceType) {
   return function(state, action) {
     // Ignore actions that were dispatched for another resource type
-    if (action.resourceName !== resourceName) {
+    const typeToUse = action.resourceType || action.resourceName;
+    if (typeToUse !== resourceType) {
       return state;
     }
 
@@ -53,7 +54,7 @@ function selection(resourceName) {
 
       return {
         ...state,
-        selectedIds
+        selectedIds,
       };
     } else if (action.type === actionTypes.DESELECT_RESOURCES) {
       selectedIds = [...state.selectedIds] || [];
@@ -61,12 +62,12 @@ function selection(resourceName) {
 
       return {
         ...state,
-        selectedIds: selectedIds.filter(id => !resourceIds.includes(id))
+        selectedIds: selectedIds.filter(id => !resourceIds.includes(id)),
       };
     } else if (action.type === actionTypes.CLEAR_SELECTED_RESOURCES) {
       return {
         ...state,
-        selectedIds: []
+        selectedIds: [],
       };
     }
 

--- a/packages/redux-resource-xhr/src/index.js
+++ b/packages/redux-resource-xhr/src/index.js
@@ -10,10 +10,11 @@ function crudRequest(crudAction, options) {
     onPending,
     onFailed,
     onSucceeded,
-    onAborted
+    onAborted,
   } = options;
 
-  const { resourceName } = actionDefaults;
+  const { resourceName, resourceType } = actionDefaults;
+  const typeToUse = resourceType || resourceName;
 
   const crudActionOption = crudAction ? crudAction : '';
 
@@ -27,10 +28,10 @@ function crudRequest(crudAction, options) {
       lowercaseCrud === 'create';
     const { url, uri } = xhrOptions;
 
-    if (!resourceName) {
+    if (!typeToUse) {
       console.warn(
-        `A resourceName was not passed to a Redux Resource Action ` +
-          `creator. A resourceName must be passed so that Redux Resource ` +
+        `A resourceType was not passed to a Redux Resource Action ` +
+          `creator. A resourceType must be passed so that Redux Resource ` +
           `knows which resource slice to update. Refer to the CRUD Actions ` +
           `guide for more: https://redux-resource.js.org/docs/guides/crud-actions.html`
       );
@@ -60,7 +61,7 @@ function crudRequest(crudAction, options) {
     type: actionTypes[`${crudType}_RESOURCES_PENDING`],
     // This may seem strange, but any unresolved request has a status code of 0
     // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/status
-    statusCode: 0
+    statusCode: 0,
   };
 
   if (onPending) {
@@ -76,7 +77,7 @@ function crudRequest(crudAction, options) {
         ...actionDefaults,
         type: actionTypes[`${crudType}_RESOURCES_IDLE`],
         statusCode,
-        res
+        res,
       };
 
       if (onAborted) {
@@ -90,7 +91,7 @@ function crudRequest(crudAction, options) {
         type: actionTypes[`${crudType}_RESOURCES_FAILED`],
         statusCode,
         res,
-        err
+        err,
       };
 
       if (onFailed) {
@@ -116,7 +117,7 @@ function crudRequest(crudAction, options) {
         type: actionTypes[`${crudType}_RESOURCES_SUCCEEDED`],
         statusCode,
         resources,
-        res
+        res,
       };
 
       if (onSucceeded) {

--- a/packages/redux-resource/src/request-statuses-plugin/index.js
+++ b/packages/redux-resource/src/request-statuses-plugin/index.js
@@ -2,23 +2,23 @@ import actionReducersMap from './action-reducers-map';
 import initialResourceMetaState from '../utils/initial-resource-meta-state';
 import warning from '../utils/warning';
 
-export default function requestStatusesPlugin(resourceName, options = {}) {
+export default function requestStatusesPlugin(resourceType, options = {}) {
   const customInitialMeta = options.initialResourceMeta || {};
   const optionsToSend = {
     initialResourceMeta: {
       ...initialResourceMetaState,
-      ...customInitialMeta
-    }
+      ...customInitialMeta,
+    },
   };
 
   return function(state, action) {
     const reducer = actionReducersMap[action.type];
 
     if (process.env.NODE_ENV !== 'production') {
-      if (reducer && !action.resourceName) {
+      if (reducer && !action.resourceName && !action.resourceType) {
         warning(
-          `A resourceName was not included in an action with type ` +
-            `"${action.type}". Without a resourceName, Redux Resource will ` +
+          `A resourceType was not included in an action with type ` +
+            `"${action.type}". Without a resourceType, Redux Resource will ` +
             `not be able to update a slice of your store. For more, refer to ` +
             `the guide on CRUD Actions: ` +
             `https://redux-resource.js.org/docs/guides/crud-actions.html`
@@ -26,11 +26,13 @@ export default function requestStatusesPlugin(resourceName, options = {}) {
       }
     }
 
-    if (action.resourceName !== resourceName) {
+    const actionResourceType = action.resourceType || action.resourceName;
+
+    if (actionResourceType !== resourceType) {
       return state;
     }
 
-    const callActionReducer = reducer && action.resourceName === resourceName;
+    const callActionReducer = reducer && actionResourceType === resourceType;
     return callActionReducer ? reducer(state, action, optionsToSend) : state;
   };
 }

--- a/packages/redux-resource/src/resource-reducer.js
+++ b/packages/redux-resource/src/resource-reducer.js
@@ -6,22 +6,22 @@ import warning from './utils/warning';
 
 // Create a resource reducer.
 //
-// `resourceName`: the plural name of your resource. For instance, "books".
+// `resourceType`: the kind of resource that this slice represents. For instance, "books".
 // `options`: pass options to change the behavior of the reducer. See the docs
 //   for more information on the available options.
-export default function resourceReducer(resourceName, options = {}) {
+export default function resourceReducer(resourceType, options = {}) {
   const { plugins = [], initialState = {} } = options;
   const defaultInitialState = generateDefaultInitialState();
   const initial = {
     ...defaultInitialState,
     ...initialState,
-    resourceName,
+    resourceType,
   };
 
   if (process.env.NODE_ENV !== 'production') {
-    if (typeof resourceName !== 'string') {
+    if (typeof resourceType !== 'string') {
       warning(
-        `The value of "resourceName" that you passed to resourceReducer was ` +
+        `The value of "resourceType" that you passed to resourceReducer was ` +
           `not a string. The resource name must be a string. You should check ` +
           `your reducer configuration.`
       );
@@ -34,7 +34,7 @@ export default function resourceReducer(resourceName, options = {}) {
   );
 
   const computedPlugins = allPlugins.map(plugin => {
-    const result = plugin(resourceName, options);
+    const result = plugin(resourceType, options);
     if (process.env.NODE_ENV !== 'production') {
       if (typeof result !== 'function') {
         warning(

--- a/packages/redux-resource/src/update-resources-plugin/index.js
+++ b/packages/redux-resource/src/update-resources-plugin/index.js
@@ -1,19 +1,19 @@
 import upsertResources from '../utils/upsert-resources';
 import upsertMeta from '../utils/upsert-meta';
 
-export default resourceName => (state, action) => {
+export default resourceType => (state, action) => {
   if (action.type !== 'UPDATE_RESOURCES') {
     return state;
   }
 
-  const naiveNewResources = action.resources && action.resources[resourceName];
-  const naiveNewMeta = action.meta && action.meta[resourceName];
+  const naiveNewResources = action.resources && action.resources[resourceType];
+  const naiveNewMeta = action.meta && action.meta[resourceType];
 
   let mergeResources;
   if (typeof action.mergeResources === 'boolean') {
     mergeResources = action.mergeResources;
   } else if (typeof action.mergeResources === 'object') {
-    mergeResources = action.mergeResources[resourceName];
+    mergeResources = action.mergeResources[resourceType];
   } else {
     mergeResources = true;
   }
@@ -22,7 +22,7 @@ export default resourceName => (state, action) => {
   if (typeof action.mergeMeta === 'boolean') {
     mergeMeta = action.mergeMeta;
   } else if (typeof action.mergeMeta === 'object') {
-    mergeMeta = action.mergeMeta[resourceName];
+    mergeMeta = action.mergeMeta[resourceType];
   } else {
     mergeMeta = true;
   }
@@ -41,7 +41,7 @@ export default resourceName => (state, action) => {
   }
 
   let newLists = state.lists;
-  const additionalLists = action.lists && action.lists[resourceName];
+  const additionalLists = action.lists && action.lists[resourceType];
 
   if (additionalLists) {
     newLists = {

--- a/packages/redux-resource/test/unit/reducers/create.js
+++ b/packages/redux-resource/test/unit/reducers/create.js
@@ -11,36 +11,76 @@ describe('reducers: create', function() {
         resources: {
           1: { id: 1 },
           3: { id: 3 },
-          4: { id: 4 }
+          4: { id: 4 },
         },
         requests: {
           pasta: {
-            hungry: true
-          }
+            hungry: true,
+          },
         },
         lists: {
-          bookmarks: [1, 2, 3]
+          bookmarks: [1, 2, 3],
         },
         meta: {
           1: {
-            name: 'what'
+            name: 'what',
           },
           3: {
-            deleteStatus: 'sandwiches'
-          }
-        }
+            deleteStatus: 'sandwiches',
+          },
+        },
       };
 
       const reducer = resourceReducer('hellos', { initialState });
 
       const reduced = reducer(undefined, {
         type: 'CREATE_RESOURCES_SUCCEEDED',
-        resourceName: 'hellos'
+        resourceType: 'hellos',
       });
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos'
+        resourceType: 'hellos',
+      });
+      expect(console.error.callCount).to.equal(1);
+    });
+
+    it('(deprecated) returns the right state without a request name, without IDs (resourceName)', () => {
+      stub(console, 'error');
+      const initialState = {
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4 },
+        },
+        requests: {
+          pasta: {
+            hungry: true,
+          },
+        },
+        lists: {
+          bookmarks: [1, 2, 3],
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+        },
+      };
+
+      const reducer = resourceReducer('hellos', { initialState });
+
+      const reduced = reducer(undefined, {
+        type: 'CREATE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+      });
+
+      expect(reduced).to.deep.equal({
+        ...initialState,
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(1);
     });

--- a/packages/redux-resource/test/unit/reducers/delete.js
+++ b/packages/redux-resource/test/unit/reducers/delete.js
@@ -31,7 +31,7 @@ describe('reducers: delete', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(1);
     });
@@ -205,7 +205,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: null,
@@ -268,7 +268,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           0: null,
           3: { id: 3 },
@@ -339,7 +339,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: null,
@@ -418,7 +418,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: null,
@@ -496,7 +496,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: null,
@@ -567,7 +567,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: null,
@@ -640,7 +640,7 @@ describe('reducers: delete', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },

--- a/packages/redux-resource/test/unit/reducers/index.js
+++ b/packages/redux-resource/test/unit/reducers/index.js
@@ -12,7 +12,7 @@ describe('reducer', function() {
 
     const state = {
       sandwiches: true,
-      hungry: []
+      hungry: [],
     };
 
     const reduced = reducer(state, { type: 'does_not_exist' });
@@ -20,13 +20,13 @@ describe('reducer', function() {
     expect(console.error.callCount).to.equal(0);
   });
 
-  it('should warn when no resourceName is passed', () => {
+  it('should warn when no resourceType is passed', () => {
     stub(console, 'error');
     resourceReducer();
     expect(console.error.callCount).to.equal(1);
   });
 
-  it('should warn when a non-string resourceName is passed', () => {
+  it('should warn when a non-string resourceType is passed', () => {
     stub(console, 'error');
     resourceReducer({});
     expect(console.error.callCount).to.equal(1);

--- a/packages/redux-resource/test/unit/reducers/plugins.js
+++ b/packages/redux-resource/test/unit/reducers/plugins.js
@@ -8,8 +8,8 @@ describe('reducer', function() {
       plugins: [
         () => {
           // Intentionally blank
-        }
-      ]
+        },
+      ],
     });
 
     expect(console.error.callCount).to.equal(1);
@@ -22,37 +22,37 @@ describe('reducer', function() {
           if (action.type === actionTypes.READ_RESOURCES_SUCCEEDED) {
             return {
               ...state,
-              pizza: 'yum'
+              pizza: 'yum',
             };
           }
 
           return state;
-        }
-      ]
+        },
+      ],
     });
 
     const reduced = reducer(undefined, {
       type: 'READ_RESOURCES_SUCCEEDED',
-      resourceName: 'hellos',
-      resources: [3]
+      resourceType: 'hellos',
+      resources: [3],
     });
 
     expect(reduced).to.deep.equal({
-      resourceName: 'hellos',
+      resourceType: 'hellos',
       resources: {
-        3: { id: 3 }
+        3: { id: 3 },
       },
       meta: {
         3: {
           createStatus: 'IDLE',
           readStatus: 'SUCCEEDED',
           updateStatus: 'IDLE',
-          deleteStatus: 'IDLE'
-        }
+          deleteStatus: 'IDLE',
+        },
       },
       lists: {},
       requests: {},
-      pizza: 'yum'
+      pizza: 'yum',
     });
   });
 
@@ -63,28 +63,28 @@ describe('reducer', function() {
           if (action.type === 'SANDWICHES_ARE_GOOD') {
             return {
               ...state,
-              tastiness: action.tastiness
+              tastiness: action.tastiness,
             };
           }
 
           return state;
-        }
-      ]
+        },
+      ],
     });
 
     const reduced = reducer(undefined, {
       type: 'SANDWICHES_ARE_GOOD',
-      resourceName: 'hellos',
-      tastiness: 'quite'
+      resourceType: 'hellos',
+      tastiness: 'quite',
     });
 
     expect(reduced).to.deep.equal({
-      resourceName: 'hellos',
+      resourceType: 'hellos',
       resources: {},
       meta: {},
       lists: {},
       requests: {},
-      tastiness: 'quite'
+      tastiness: 'quite',
     });
   });
 
@@ -95,7 +95,7 @@ describe('reducer', function() {
           if (action.type === 'SANDWICHES_ARE_GOOD') {
             return {
               ...state,
-              tastiness: true
+              tastiness: true,
             };
           }
 
@@ -105,27 +105,27 @@ describe('reducer', function() {
           if (action.type === 'SANDWICHES_ARE_GOOD') {
             return {
               ...state,
-              tastiness: false
+              tastiness: false,
             };
           }
 
           return state;
-        }
-      ]
+        },
+      ],
     });
 
     const reduced = reducer(undefined, {
       type: 'SANDWICHES_ARE_GOOD',
-      resourceName: 'hellos'
+      resourceType: 'hellos',
     });
 
     expect(reduced).to.deep.equal({
-      resourceName: 'hellos',
+      resourceType: 'hellos',
       resources: {},
       meta: {},
       lists: {},
       requests: {},
-      tastiness: true
+      tastiness: true,
     });
   });
 });

--- a/packages/redux-resource/test/unit/reducers/read.js
+++ b/packages/redux-resource/test/unit/reducers/read.js
@@ -40,7 +40,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -111,7 +111,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -180,7 +180,7 @@ describe('reducers: read:', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(1);
     });
@@ -222,7 +222,7 @@ describe('reducers: read:', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(1);
     });
@@ -260,7 +260,7 @@ describe('reducers: read:', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(1);
     });
@@ -300,7 +300,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -366,7 +366,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -431,7 +431,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -505,7 +505,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -590,7 +590,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -675,7 +675,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -764,7 +764,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -850,7 +850,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -924,7 +924,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -995,7 +995,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -1067,7 +1067,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -1133,7 +1133,7 @@ describe('reducers: read:', function() {
       });
 
       expect(reduced).to.deep.equal({
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1 },
           3: { id: 3 },
@@ -1202,7 +1202,7 @@ describe('reducers: read:', function() {
     });
 
     expect(reduced).to.deep.equal({
-      resourceName: 'hellos',
+      resourceType: 'hellos',
       resources: {
         1: { id: 1 },
         3: { id: 3 },

--- a/packages/redux-resource/test/unit/reducers/update-resources.js
+++ b/packages/redux-resource/test/unit/reducers/update-resources.js
@@ -36,7 +36,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(0);
     });
@@ -81,7 +81,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         lists: {
           bookmarks: [1, 2, 3],
           new: [10, 100, 1000],
@@ -134,7 +134,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         lists: {
           bookmarks: [2, 5, 6],
           new: [10, 100, 1000],
@@ -193,7 +193,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1, name: 'Test2' },
           3: { id: 3 },
@@ -250,7 +250,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1, name: 'Test2' },
           3: { id: 3 },
@@ -304,7 +304,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1, name: 'Test2' },
           3: { id: 3 },
@@ -360,7 +360,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         resources: {
           1: { id: 1, name: 'Test2' },
           3: { id: 3 },
@@ -417,7 +417,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         meta: {
           1: {
             name: 'what',
@@ -477,7 +477,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(0);
     });
@@ -525,7 +525,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         meta: {
           1: {
             name: 'Test2',
@@ -583,7 +583,7 @@ describe('reducers: UPDATE_RESOURCES', function() {
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos',
+        resourceType: 'hellos',
         meta: {
           1: {
             name: 'Test2',

--- a/packages/redux-resource/test/unit/reducers/update.js
+++ b/packages/redux-resource/test/unit/reducers/update.js
@@ -11,34 +11,72 @@ describe('reducers: update', function() {
         resources: {
           1: { id: 1 },
           3: { id: 3 },
-          4: { id: 4 }
+          4: { id: 4 },
         },
         lists: {},
         requests: {
           pasta: {
-            hungry: true
-          }
+            hungry: true,
+          },
         },
         meta: {
           1: {
-            name: 'what'
+            name: 'what',
           },
           3: {
-            deleteStatus: 'sandwiches'
-          }
-        }
+            deleteStatus: 'sandwiches',
+          },
+        },
       };
 
       const reducer = resourceReducer('hellos', { initialState });
 
       const reduced = reducer(undefined, {
         type: 'UPDATE_RESOURCES_SUCCEEDED',
-        resourceName: 'hellos'
+        resourceType: 'hellos',
       });
 
       expect(reduced).to.deep.equal({
         ...initialState,
-        resourceName: 'hellos'
+        resourceType: 'hellos',
+      });
+      expect(console.error.callCount).to.equal(1);
+    });
+
+    it('(deprecated) returns the right state without a request name, without IDs (resourceName)', () => {
+      stub(console, 'error');
+      const initialState = {
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4 },
+        },
+        lists: {},
+        requests: {
+          pasta: {
+            hungry: true,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+        },
+      };
+
+      const reducer = resourceReducer('hellos', { initialState });
+
+      const reduced = reducer(undefined, {
+        type: 'UPDATE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+      });
+
+      expect(reduced).to.deep.equal({
+        ...initialState,
+        resourceType: 'hellos',
       });
       expect(console.error.callCount).to.equal(1);
     });


### PR DESCRIPTION
This idea is more commonly referred to as a "type" or "class" than a "name."

JSON API - `type`
GraphQL - `type`
gRPC - `class`

---

Note: `resourceName` still works, it will just be deprecated in favor of `resourceType`.