### PR TITLE
Add DELETE_RESOURCES action type

### DIFF
--- a/packages/redux-resource/src/update-resources-plugin/index.js
+++ b/packages/redux-resource/src/update-resources-plugin/index.js
@@ -1,60 +1,153 @@
 import upsertResources from '../utils/upsert-resources';
 import upsertMeta from '../utils/upsert-meta';
+import initialResourceMetaState from '../utils/initial-resource-meta-state';
+import requestStatuses from '../utils/request-statuses';
+import warning from '../utils/warning';
 
-export default resourceType => (state, action) => {
-  if (action.type !== 'UPDATE_RESOURCES') {
+export default (resourceType, { initialResourceMeta }) => (state, action) => {
+  if (
+    action.type !== 'UPDATE_RESOURCES' &&
+    action.type !== 'DELETE_RESOURCES'
+  ) {
     return state;
   }
 
   const naiveNewResources = action.resources && action.resources[resourceType];
   const naiveNewMeta = action.meta && action.meta[resourceType];
+  if (action.type === 'UPDATE_RESOURCES') {
+    let mergeResources;
+    if (typeof action.mergeResources === 'boolean') {
+      mergeResources = action.mergeResources;
+    } else if (typeof action.mergeResources === 'object') {
+      mergeResources = action.mergeResources[resourceType];
+    } else {
+      mergeResources = true;
+    }
 
-  let mergeResources;
-  if (typeof action.mergeResources === 'boolean') {
-    mergeResources = action.mergeResources;
-  } else if (typeof action.mergeResources === 'object') {
-    mergeResources = action.mergeResources[resourceType];
+    let mergeMeta;
+    if (typeof action.mergeMeta === 'boolean') {
+      mergeMeta = action.mergeMeta;
+    } else if (typeof action.mergeMeta === 'object') {
+      mergeMeta = action.mergeMeta[resourceType];
+    } else {
+      mergeMeta = true;
+    }
+
+    const newResources = upsertResources(
+      state.resources,
+      naiveNewResources,
+      mergeResources
+    );
+
+    let newMeta;
+    if (!Array.isArray(naiveNewMeta)) {
+      newMeta = upsertMeta(state.meta, naiveNewMeta, mergeMeta);
+    } else {
+      newMeta = state.meta;
+    }
+
+    let newLists = state.lists;
+    const additionalLists = action.lists && action.lists[resourceType];
+
+    if (additionalLists) {
+      newLists = {
+        ...state.lists,
+        ...additionalLists,
+      };
+    }
+
+    return {
+      ...state,
+      ...action.resourceSliceAttributes,
+      resources: newResources,
+      meta: newMeta,
+      lists: newLists,
+    };
   } else {
-    mergeResources = true;
-  }
+    let idList;
+    if (naiveNewResources && naiveNewResources.map) {
+      idList = naiveNewResources.map(r => {
+        if (typeof r === 'object') {
+          if (process.env.NODE_ENV !== 'production') {
+            if (
+              (!r.id && r.id !== 0) ||
+              (typeof r.id !== 'string' && typeof r.id !== 'number')
+            ) {
+              warning(
+                `A resource without an ID was passed to an action with type ` +
+                  `${
+                    action.type
+                  }. Every resource must have an ID that is either ` +
+                  `a number of a string. You should check your action creators to ` +
+                  `make sure that an ID is always included in your resources.`
+              );
+            }
+          }
+          return r.id;
+        } else {
+          if (process.env.NODE_ENV !== 'production') {
+            if (typeof r !== 'string' && typeof r !== 'number') {
+              warning(
+                `A resource without an ID was passed to an action with type ` +
+                  `${
+                    action.type
+                  }. Every resource must have an ID that is either ` +
+                  `a number of a string. You should check your action creators to ` +
+                  `make sure that an ID is always included in your resources.`
+              );
+            }
+          }
+          return r;
+        }
+      });
+    } else {
+      idList = Object.keys(naiveNewResources || {});
+    }
 
-  let mergeMeta;
-  if (typeof action.mergeMeta === 'boolean') {
-    mergeMeta = action.mergeMeta;
-  } else if (typeof action.mergeMeta === 'object') {
-    mergeMeta = action.mergeMeta[resourceType];
-  } else {
-    mergeMeta = true;
-  }
+    const hasIds = idList && idList.length;
+    if (!hasIds) {
+      return state;
+    }
 
-  const newResources = upsertResources(
-    state.resources,
-    naiveNewResources,
-    mergeResources
-  );
+    let newMeta;
+    let newLists = {};
+    const meta = state.meta;
+    const lists = state.lists;
 
-  let newMeta;
-  if (!Array.isArray(naiveNewMeta)) {
-    newMeta = upsertMeta(state.meta, naiveNewMeta, mergeMeta);
-  } else {
-    newMeta = state.meta;
-  }
+    for (let resourceList in lists) {
+      const existingList = lists[resourceList];
+      newLists[resourceList] = existingList.filter(r => !idList.includes(r));
+    }
 
-  let newLists = state.lists;
-  const additionalLists = action.lists && action.lists[resourceType];
+    const nullMeta = idList.reduce((memo, id) => {
+      const newMeta = (naiveNewMeta || {})[id];
+      memo[id] = {
+        ...initialResourceMetaState,
+        ...initialResourceMeta,
+        ...newMeta,
+        deleteStatus: requestStatuses.SUCCEEDED,
+      };
+      return memo;
+    }, {});
 
-  if (additionalLists) {
-    newLists = {
-      ...state.lists,
-      ...additionalLists,
+    newMeta = {
+      ...meta,
+      ...nullMeta,
+    };
+
+    // Shallow clone the existing resource object, nulling any deleted resources
+    let newResources = Object.assign({}, state.resources);
+    if (hasIds) {
+      idList.forEach(id => {
+        newResources[id] = null;
+      });
+    }
+
+    return {
+      ...state,
+      meta: newMeta,
+      lists: newLists,
+      resources: newResources,
     };
   }
-
-  return {
-    ...state,
-    ...action.resourceSliceAttributes,
-    resources: newResources,
-    meta: newMeta,
-    lists: newLists,
-  };
 };

--- a/packages/redux-resource/test/unit/reducers/delete-resources.js
+++ b/packages/redux-resource/test/unit/reducers/delete-resources.js
@@ -1,0 +1,428 @@
+import { resourceReducer, requestStatuses } from '../../../src';
+
+describe('reducers: DELETE_RESOURCES', function() {
+  describe('When nothing else is passed', () => {
+    it('does not change the state', () => {
+      stub(console, 'error');
+      const initialState = {
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4 },
+        },
+        requests: {
+          pasta: {
+            hungry: true,
+          },
+        },
+        lists: {
+          bookmarks: [1, 2, 3],
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+        },
+      };
+
+      const reducer = resourceReducer('hellos', { initialState });
+
+      const reduced = reducer(undefined, {
+        type: 'DELETE_RESOURCES',
+      });
+
+      expect(reduced).to.deep.equal({
+        ...initialState,
+        resourceType: 'hellos',
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+  });
+
+  it('logs a warning when a resource does not have an ID (obj form)', () => {
+    stub(console, 'error');
+    const reducer = resourceReducer('hellos', {
+      initialState: {
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4 },
+        },
+        lists: {},
+        requests: {},
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+        },
+      },
+      initialResourceMeta: {
+        selected: false,
+      },
+    });
+
+    reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        hellos: [3, { name: 'sandwiches' }],
+      },
+    });
+
+    expect(console.error.callCount).to.equal(1);
+  });
+
+  it('logs a warning when a resource ID is a non-string or non-integer', () => {
+    stub(console, 'error');
+    const reducer = resourceReducer('hellos', {
+      initialState: {
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4 },
+        },
+        lists: {},
+        requests: {},
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+        },
+      },
+      initialResourceMeta: {
+        selected: false,
+      },
+    });
+
+    reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        hellos: [true, { id: 5, name: 'sandwiches' }],
+      },
+    });
+
+    expect(console.error.callCount).to.equal(1);
+  });
+
+  it('accepts an array of objects; deletes resources and their meta', () => {
+    stub(console, 'error');
+    const initialState = {
+      resources: {
+        1: { id: 1, name: 'Test' },
+        3: { id: 3 },
+        4: { id: 4 },
+      },
+      requests: {
+        pasta: {
+          hungry: true,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          name: 'what',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+      },
+    };
+
+    const reducer = resourceReducer('hellos', { initialState });
+
+    const reduced = reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        hellos: [
+          {
+            id: 1,
+            name: 'Test2',
+          },
+          {
+            id: 13,
+            name: 'Test3',
+          },
+        ],
+      },
+    });
+
+    expect(reduced).to.deep.equal({
+      ...initialState,
+      resourceType: 'hellos',
+      resources: {
+        1: null,
+        3: { id: 3 },
+        4: { id: 4 },
+        13: null,
+      },
+      lists: {
+        bookmarks: [2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+        13: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+      },
+    });
+    expect(console.error.callCount).to.equal(0);
+  });
+
+  it('accepts an array of objects; deletes resources and their meta, allowing you to add additional meta', () => {
+    stub(console, 'error');
+    const initialState = {
+      resources: {
+        1: { id: 1, name: 'Test' },
+        3: { id: 3 },
+        4: { id: 4 },
+      },
+      requests: {
+        pasta: {
+          hungry: true,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          name: 'what',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+      },
+    };
+
+    const reducer = resourceReducer('hellos', { initialState });
+
+    const reduced = reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        hellos: [
+          {
+            id: 1,
+            name: 'Test2',
+          },
+          {
+            id: 13,
+            name: 'Test3',
+          },
+        ],
+      },
+      meta: {
+        hellos: {
+          1: {
+            deletedBy: 'james please',
+          },
+        },
+      },
+    });
+
+    expect(reduced).to.deep.equal({
+      ...initialState,
+      resourceType: 'hellos',
+      resources: {
+        1: null,
+        3: { id: 3 },
+        4: { id: 4 },
+        13: null,
+      },
+      lists: {
+        bookmarks: [2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+          deletedBy: 'james please',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+        13: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+      },
+    });
+    expect(console.error.callCount).to.equal(0);
+  });
+
+  it('accepts an array of IDs; deletes resources and their meta', () => {
+    stub(console, 'error');
+    const initialState = {
+      resources: {
+        1: { id: 1, name: 'Test' },
+        3: { id: 3 },
+        4: { id: 4 },
+      },
+      requests: {
+        pasta: {
+          hungry: true,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          name: 'what',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+      },
+    };
+
+    const reducer = resourceReducer('hellos', { initialState });
+
+    const reduced = reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        hellos: [
+          1,
+          {
+            id: 13,
+            name: 'Test3',
+          },
+        ],
+      },
+    });
+
+    expect(reduced).to.deep.equal({
+      ...initialState,
+      resourceType: 'hellos',
+      resources: {
+        1: null,
+        3: { id: 3 },
+        4: { id: 4 },
+        13: null,
+      },
+      lists: {
+        bookmarks: [2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+        13: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+      },
+    });
+    expect(console.error.callCount).to.equal(0);
+  });
+
+  it('accepts an array of IDs; leaves lists alone when there is nothing to change', () => {
+    stub(console, 'error');
+    const initialState = {
+      resources: {
+        1: { id: 1, name: 'Test' },
+        3: { id: 3 },
+        4: { id: 4 },
+      },
+      requests: {
+        pasta: {
+          hungry: true,
+        },
+      },
+      lists: {
+        bookmarks: [2, 3],
+        new: [10, 100, 1000],
+      },
+      meta: {
+        1: {
+          name: 'what',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+      },
+    };
+
+    const reducer = resourceReducer('hellos', { initialState });
+
+    const reduced = reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        hellos: [
+          1,
+          {
+            id: 13,
+            name: 'Test3',
+          },
+        ],
+      },
+    });
+
+    expect(reduced).to.deep.equal({
+      ...initialState,
+      resourceType: 'hellos',
+      resources: {
+        1: null,
+        3: { id: 3 },
+        4: { id: 4 },
+        13: null,
+      },
+      meta: {
+        1: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+        13: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.SUCCEEDED,
+        },
+      },
+    });
+    expect(console.error.callCount).to.equal(0);
+  });
+});


### PR DESCRIPTION
This is part of #319 

---

This completes CRUD'ing the store independent from requests:

`UPDATE_RESOURCES` => create+update
`DELETE_RESOURCES` => delete
`getResources()` => read
